### PR TITLE
First implementation of VGA support.

### DIFF
--- a/test/vgatest.lua
+++ b/test/vgatest.lua
@@ -1,0 +1,15 @@
+-- Initialize the VGA mode (320x200 256-color mode)
+vga_init(0x13)
+
+-- Function to draw a filled rectangle
+function draw_filled_rectangle(x, y, width, height, color)
+    -- Loop through the height and width to plot each pixel in the rectangle
+    for i = 0, width - 1 do
+        for j = 0, height - 1 do
+            put_pixel(x + i, y + j, color)  -- Draw pixel at (x + i, y + j)
+        end
+    end
+end
+
+-- Draw a filled rectangle at position (50, 50) with width 100 and height 50, using color 15 (white)
+draw_filled_rectangle(50, 50, 100, 50, 15)


### PR DESCRIPTION
First implementation of VGA support.
It seems the far pointer is not pointing to the correct location in video memory. 
It does switch to 0x13 vga mode, but it does not draw a rectangle. Not error is given either.