### PR TITLE
VGA support with a working rotating cube for Lua 5.5

### DIFF
--- a/testes/drawcube.lua
+++ b/testes/drawcube.lua
@@ -1,0 +1,76 @@
+-- Initialize the VGA mode (320x200 256-color mode)
+vga_init(0x13)
+
+-- Cube vertices (8 points in 3D space)
+local cube = {
+{-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
+{-1, -1, 1}, {1, -1, 1}, {1, 1, 1}, {-1, 1, 1}
+}
+
+-- Cube edges (pairs of indices)
+local edges = {
+  {1, 2}, {2, 3}, {3, 4}, {4, 1}, -- Back face
+  {5, 6}, {6, 7}, {7, 8}, {8, 5}, -- Front face
+  {1, 5}, {2, 6}, {3, 7}, {4, 8} -- Connecting edges
+}
+
+local angleX, angleY = 0, 0 -- Rotation angles
+local size = 40 -- Cube size
+local fov = 3 -- Field of view
+
+-- Function to rotate around X-axis
+local function rotateX(x, y, z, angle)
+  local cosA, sinA = math.cos(angle), math.sin(angle)
+  return x, y * cosA - z * sinA, y * sinA + z * cosA
+end
+
+-- Function to rotate around Y-axis
+local function rotateY(x, y, z, angle)
+  local cosA, sinA = math.cos(angle), math.sin(angle)
+  return x * cosA + z * sinA, y, -x * sinA + z * cosA
+end
+
+-- Function to project 3D point to 2D
+local function project3D(x, y, z)
+  local scale = fov / (fov + z) -- Perspective projection
+  local screenX = x * scale * size + 160 -- Center at (160, 100)
+  local screenY = y * scale * size + 100
+  return screenX, screenY
+end
+
+while true do
+-- Clear screen
+   for x = 0, 319 do
+    for y = 0, 199 do
+      plot_pixel(x, y, 0) -- Black
+    end
+   end
+
+   local transformed = {}
+
+-- Rotate and project each vertex
+   for i, v in ipairs(cube) do
+     local x, y, z = v[1], v[2], v[3]
+
+     -- Apply both rotations
+     local rx, ry, rz = rotateX(x, y, z, angleX)
+     local finalX, finalY, finalZ = rotateY(rx, ry, rz, angleY)
+
+     -- Project after both rotations
+     local screenX, screenY = project3D(finalX, finalY, finalZ)
+     transformed[i] = {screenX, screenY} -- Store the transformed screen coordinates
+   end
+
+-- Draw cube edges
+   for _, edge in ipairs(edges) do
+      local p1, p2 = transformed[edge[1]], transformed[edge[2]]
+      plot_line(p1[1], p1[2], p2[1], p2[2], 15)  -- White color
+   end
+
+-- Update rotation
+   angleX = angleX + (5 / 100)
+   angleY = angleY + (3 / 100)
+
+-- Delay to control speed
+-- delay(30)
+end

--- a/testes/vgatest.lua
+++ b/testes/vgatest.lua
@@ -1,0 +1,18 @@
+-- Initialize the VGA mode (320x200 256-color mode)
+vga_init(0x13)
+
+-- Function to draw a filled rectangle
+function draw_filled_rectangle(x, y, width, height, color)
+    -- Loop through the height and width to plot each pixel in the rectangle
+    for i = 0, width - 1 do
+        for j = 0, height - 1 do
+            plot_pixel(x + i, y + j, color)  -- Draw pixel at (x + i, y + j)
+        end
+    end
+end
+
+-- Draw a filled rectangle at position (50, 50) with width 100 and height 50, using color 15 (white)
+draw_filled_rectangle(50, 50, 100, 50, 15)
+draw_filled_rectangle(100, 100, 100, 50, 4)
+
+vga_init(0x03)


### PR DESCRIPTION
Now it works for 5.5!
Thanks both @rafael2k and @ghaerr.
Here is an image: [elks_lua.zip](https://github.com/user-attachments/files/19123234/elks_lua.zip)
`./lua ./drawcube.lua`

It might be very slow on real hardware, but there is space for optimization. For example, we do not need to clear the entire screen for each new frame. Actually we can draw the same cube with color 0 instead. Unfortunately there is no native sleep(). 


