### PR TITLE
Added sleep_ms and much improved cube rotation demo for Lua 5.5

### DIFF
--- a/lbaselib.c
+++ b/lbaselib.c
@@ -21,6 +21,8 @@
 #include "lualib.h"
 #include "llimits.h"
 
+#include <unistd.h>
+
 typedef unsigned char  byte;
 byte __far *VGA = (byte __far *)0xA0000000L;
 
@@ -513,6 +515,7 @@ static int luaB_tostring (lua_State *L) {
   return 1;
 }
 
+//START non-standard functions
 static int luaB_vga_init(lua_State *L)
 {
   lua_Number mode = luaL_checknumber(L, 1);  // Get the argument
@@ -586,6 +589,18 @@ static int luaB_plot_line(lua_State *L)
     return 1;
 }
 
+static int luaB_sleep_ms(lua_State *L)
+{
+  lua_Number number = luaL_checknumber(L, 1);
+  unsigned int ms = (unsigned int) number;
+
+  usleep(1000 * ms);
+
+  return 1;
+}
+
+//END non-standard functions
+
 static const luaL_Reg base_funcs[] = {
   {"assert", luaB_assert},
   {"collectgarbage", luaB_collectgarbage},
@@ -613,6 +628,7 @@ static const luaL_Reg base_funcs[] = {
   {"vga_init", luaB_vga_init},
   {"plot_pixel", luaB_plot_pixel},
   {"plot_line", luaB_plot_line},
+  {"sleep_ms", luaB_sleep_ms},
   /* placeholders */
   {LUA_GNAME, NULL},
   {"_VERSION", NULL},

--- a/testes/drawcube.lua
+++ b/testes/drawcube.lua
@@ -38,13 +38,25 @@ local function project3D(x, y, z)
   return screenX, screenY
 end
 
+local function shallow_copy(orig)
+    local copy = {}  -- Create a new table
+    for k, v in pairs(orig) do
+        copy[k] = {v[1], v[2]}  -- Copy the inner table manually
+    end
+    return copy
+end
+
+local old_transformed = {}
+
+local function main ()
+
 while true do
 -- Clear screen
-   for x = 0, 319 do
-    for y = 0, 199 do
-      plot_pixel(x, y, 0) -- Black
-    end
-   end
+   --for x = 0, 319 do
+   -- for y = 0, 199 do
+   --   plot_pixel(x, y, 0) -- Black
+   -- end
+   --end
 
    local transformed = {}
 
@@ -61,6 +73,14 @@ while true do
      transformed[i] = {screenX, screenY} -- Store the transformed screen coordinates
    end
 
+-- Clear cube
+   for _, edge in ipairs(edges) do
+      local p1, p2 = old_transformed[edge[1]], old_transformed[edge[2]]
+      if p1 and p2 then
+         plot_line(p1[1], p1[2], p2[1], p2[2], 0)  -- black color
+      end
+   end
+
 -- Draw cube edges
    for _, edge in ipairs(edges) do
       local p1, p2 = transformed[edge[1]], transformed[edge[2]]
@@ -68,9 +88,22 @@ while true do
    end
 
 -- Update rotation
+   --missing angle reset: if angle > 2 math.pi angle = 0
    angleX = angleX + (5 / 100)
    angleY = angleY + (3 / 100)
 
+-- Save previous
+   old_transformed = shallow_copy(transformed)
+
 -- Delay to control speed
--- delay(30)
+   sleep_ms(20)
+
+end
+end 
+
+local success, err = pcall(main)
+
+if not success then
+    vga_init(3)
+    print("Interrupted! Exiting gracefully.")
 end


### PR DESCRIPTION
Added sleep_ms
Updated the drawcube.lua to be much faster, by clearing only the previous cube instead of the whole screen
Captures CTRL+C now to stop rotation.

Here is a demo:
[elks_lua.zip](https://github.com/user-attachments/files/19142862/elks_lua.zip)
`./lua ./drawcube.lua`
